### PR TITLE
Fix for location check process

### DIFF
--- a/app/src/JourneyCore.js
+++ b/app/src/JourneyCore.js
@@ -304,8 +304,10 @@ define(function(require, exports, module)
 		 */
 		function sendCurrentPhase()
 		{
-			if (currPhase.phase === p.Live && checkDelayedLocRemaining--)
+			if (currPhase.phase === p.Live && checkDelayedLocRemaining > 0)
 			{
+				checkDelayedLocRemaining--;
+
 				var loc = adapter.map.getInvites()[0].getInvite().location;
 				console.log('******** Checking for location!! --> ', loc);
 				if (!loc)


### PR DESCRIPTION
- infinite timeout loop after the 2nd Live phase event

(e.g. for AAA the flow is live -> arrived -> live)

@Glympse/web, PTAL.