### PR TITLE
adapter dep version bumped (with fix for events stream)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "requirejs": "~2.1.20",
     "almond": "~0.3.1",
-    "glympse-adapter": "^2.10.0"
+    "glympse-adapter": "^2.11.1"
   }
 }


### PR DESCRIPTION
Just the adapter's  version bump, so only need to verify in conjunctions with journey/servtech(2).
Then will need to release new version of the journey-core and use it in the journey/servtech(2).

@Glympse/web, PTAL.