### PR TITLE
#157818608 - Refactor TruGreen journey to utilize `quasi_range` property on invite

### DIFF
--- a/app/src/JourneyCore.js
+++ b/app/src/JourneyCore.js
@@ -346,19 +346,43 @@ define(function(require, exports, module)
 			}
 
 			// Don't estimate if we haven't yet received an ETA
-			if (!currEta || currEta.eta === cUndefined || currEta.eta === null)
+			if (!currEta)
+			{
+				return;
+			}
+			// Don't estimate if latest eta object is empty
+			if ((currEta.eta === cUndefined || currEta.eta === null) && !currEta.from && !currEta.to)
 			{
 				return;
 			}
 
-			var invite = adapter.map.getInvites()[0];
-			var eta = invite.getEtaEstimate() * 1000;
-			var t = new Date().getTime();
+			var now = new Date().getTime();
+			var timeElapsed = now - currEta.eta_ts;
 
-			if (!isNaN(eta))
+			if (currEta.eta)
 			{
-				// Only send valid ETAs from the viewer
-				sendState(adapterState.Eta, t, { eta: (eta > 0) ? eta : 0, eta_ts: t });
+				var eta = currEta.eta - timeElapsed;
+				if (eta < 0)
+				{
+					eta = 0;
+				}
+
+				if (!isNaN(eta))
+				{
+					// Only send valid ETAs from the viewer
+					sendState(adapterState.Eta, t, {eta: (eta > 0) ? eta : 0, eta_ts: now});
+				}
+			}
+			else
+			{
+				var etaFrom = currEta.from - timeElapsed;
+				var etaTo = currEta.to - timeElapsed;
+				if (etaFrom < 0 && etaTo < 0)
+				{
+					etaFrom = 0;
+					etaTo = 0;
+				}
+				sendState(adapterState.EtaRange, t, {from: etaFrom, to: etaTo, eta_ts: now});
 			}
 
 			if (etaUpdateInterval > 0)
@@ -401,6 +425,13 @@ define(function(require, exports, module)
 						}
 					}
 
+					currEta = val;
+					updateEstimatedEta();
+					return;
+				}
+
+				case adapterState.EtaRange:
+				{
 					currEta = val;
 					updateEstimatedEta();
 					return;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157818608

Repeat latest eta or eta_range event in case no events were handled for the last 30 seconds

@Glympse/web PTAL