### PR TITLE
#158612533 Remove passing in of survey Ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,6 @@ config). Below is the current config format to used by GJC's Feedback handler:
 **`baseUrl`** | _URL_path_ | URL to feedback upload service. $INVITE tokens are replaced with viewed invite.
 **`dbg`** | _int_ | Debug setting. Set to > 0 to enable console debug output.
 **`surveyId`** | _INT_ | Survey identifier
-**`surveyIdInfo`** | _Array_ | Array of additional identifiers to use for a given survey.
-**`surveyOptions`** | _Array_ | Optional array of additional options to include with the survey.
 
 
 ## ViewManager setup

--- a/app/src/models/providers/enroute.js
+++ b/app/src/models/providers/enroute.js
@@ -98,23 +98,22 @@ define(function(require, exports, module)
 		function sendFeedback(vals)
 		{
 			var i, len;
+			var id = 0;
 			var items = [];
-			var idInfo = cfg.surveyIdInfo;
-			var idOptions = cfg.surveyOptions;
 
-			if (idInfo && vals.info)
+			if (vals.info)
 			{
-				for (i = 0, len = idInfo.length; i < len; i++)
+				for (i = 0, len = vals.info.length; i < len; i++, id++)
 				{
-					items.push({ _id: idInfo[i], value: vals.info[i] });
+					items.push({ _id: id, value: vals.info[i] });
 				}
 			}
 
-			if (idOptions && vals.options)
+			if (vals.options)
 			{
-				for (i = 0, len = idOptions.length; i < len; i++)
+				for (i = 0, len = vals.options.length; i < len; i++, id++)
 				{
-					items.push({ _id: idOptions[i], value: vals.options[i] });
+					items.push({ _id: id, value: vals.options[i] });
 				}
 			}
 

--- a/app/src/test-client/index.html
+++ b/app/src/test-client/index.html
@@ -44,8 +44,6 @@
 					, "dbg": 0
 					, "surveyId": 103
 					, "surveyIdRating": 110
-					, "surveyIdInfo": [ 111 ]
-					, "surveyOptions": [ ]
 				}
 				, ratings: {
 					accumulate: true


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158612533

Journey side change here: https://github.com/Glympse/enroute-journey/pull/606

Remove survey id logic (surveyIdInfo and surveyOptions) and generate them via integer incrementing. 

Per solutions team, these IDs are not used by them in any way, nor are partners using or expecting them. However, the endpoint still expects it, so we are keeping them; just generating them instead to avoid any duplicate ID issues. [developer.glympse.com/docs/enroute/api/reference/events/invites](developer.glympse.com/docs/enroute/api/reference/events/invites) (or [https://github.com/Glympse/enroute-core-api/blob/2bc5db2e33df52354ef342e5e6338788570ee51c/api/objects/event.py#L42](https://github.com/Glympse/enroute-core-api/blob/2bc5db2e33df52354ef342e5e6338788570ee51c/api/objects/event.py#L42))

@Glympse/web PTAL